### PR TITLE
Fix typos in test template

### DIFF
--- a/modules/screenshotone/public/views/pages/test.liquid
+++ b/modules/screenshotone/public/views/pages/test.liquid
@@ -8,14 +8,14 @@ slug: shoot_test
     assign id = 1234 
     assign table = "modules/example/table"
     assign name = "example_name"
-    assign url: "ttps://www.example.com"
+    assign url = "https://www.example.com"
 
 %}
 
 {% liquid
     function shoot =  "modules/screenshotone/shoot", url: url
     graphql uploaded_image = "modules/screenshotone/upload_screenshot", id: id, remote_url: shoot.cache_url, name: name
-    print ploaded_image
+    print uploaded_image
     assign url = uploaded_image | dig: "record_update", "image", "url"
 %}
 

--- a/modules/screenshotone/public/views/partials/shoot.liquid
+++ b/modules/screenshotone/public/views/partials/shoot.liquid
@@ -58,6 +58,3 @@
 {% graphql updated_record = "modules/screenshotone/upload_screenshot", args: args %}
 {% log updated_record, type: "updated_record" %}
 {% return updated_record %}
-
-
-


### PR DESCRIPTION
## Summary
- correct URL assignment and variable name in `test.liquid`
- remove trailing blank lines in `shoot.liquid`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684bb2dc6e148322a73a1bb7c5899644